### PR TITLE
Refactor CartItem: Replace onBlur with onChange for Improved UI Responsiveness

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "description": "Sample Shopping Cart to Explore using RTK",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "scripts": {
     "dev": "vite",
     "startC": "BROWSER=google-chrome vite --open",

--- a/src/features/cart/CartItem.tsx
+++ b/src/features/cart/CartItem.tsx
@@ -15,7 +15,10 @@ const CartItem = ({ id, quantity }: ICartItemProps) => {
   const dispatch = useAppDispatch();
   const { products } = useAppSelector(ProductsState);
 
-  function onQuantityChange(e: React.FocusEvent<HTMLInputElement>, id: string) {
+  function onQuantityChange(
+    e: React.ChangeEvent<HTMLInputElement>,
+    id: string,
+  ) {
     const quantity = Number(e.target.value) || 1;
     dispatch(updateQuantity({ id, quantity: quantity >= 1 ? quantity : 1 }));
   }
@@ -27,10 +30,9 @@ const CartItem = ({ id, quantity }: ICartItemProps) => {
         <input
           type="number"
           className={styles.input}
+          value={quantity}
           defaultValue={quantity >= 1 ? quantity : 1}
-          onBlur={(e) => {
-            onQuantityChange(e, id);
-          }}
+          onChange={(e) => onQuantityChange(e, id)}
         />
       </td>
       <td>{products[id].price}</td>

--- a/src/features/cart/CartItem.tsx
+++ b/src/features/cart/CartItem.tsx
@@ -30,8 +30,7 @@ const CartItem = ({ id, quantity }: ICartItemProps) => {
         <input
           type="number"
           className={styles.input}
-          value={quantity}
-          defaultValue={quantity >= 1 ? quantity : 1}
+          value={quantity >= 1 ? quantity : 1}
           onChange={(e) => onQuantityChange(e, id)}
         />
       </td>


### PR DESCRIPTION
Replace onBlur with onChange due to user preference for snappier UI, Users consider having the number of item not reflecting right away on the total price a bug, this PR resolve the issue 